### PR TITLE
Use info points URL of the 'settings' object

### DIFF
--- a/app/Application.js
+++ b/app/Application.js
@@ -153,7 +153,7 @@ define([
 
       // feature layer with centroids of buildings - displayed on top of buildings to show which buildings contain information from wikipedia
       var infoPoints = new FeatureLayer({
-        url: "https://services2.arcgis.com/cFEFS0EWrhfDeVw9/ArcGIS/rest/services/Centroids_Manhattan_Information/FeatureServer/0",
+        url: settings.infoPointsUrl,
         popupEnabled: false,
         // relative to scene displays icons on top of buildings
         elevationInfo: {


### PR DESCRIPTION
It's just a very little fix, but maybe it helps other people not to run into the same confusion of 'but why is the app still using Manhattan data instead of ours?' like in our case 😄 